### PR TITLE
Prevent segfault when ttyname() has an error.

### DIFF
--- a/launch/launch.c
+++ b/launch/launch.c
@@ -328,8 +328,10 @@ static void find_vt(char * vt, size_t size)
 
 static int open_tty(const char * tty_name)
 {
+    char *stdin_tty;
     /* Check if we are running on the desired VT */
-    if (strcmp(tty_name, ttyname(STDIN_FILENO)) == 0)
+    if ((stdin_tty = ttyname(STDIN_FILENO)) &&
+            (strcmp(tty_name, stdin_tty) == 0))
         return STDIN_FILENO;
     else
     {


### PR DESCRIPTION
There is a segfault in open_tty when ttyname(3) encounters an error and returns NULL. I'm not sure what the error is exactly, but it occurs whenever I try to run swc-launch as a systemd service.

By ignoring the error, I can run swc-launch as a systemd service just fine.