### PR TITLE
Fix for libinput 0.9

### DIFF
--- a/libswc/keyboard.c
+++ b/libswc/keyboard.c
@@ -216,12 +216,13 @@ struct wl_resource * keyboard_bind(struct keyboard * keyboard,
                                          version, id);
     wl_resource_set_implementation(client_resource, &keyboard_implementation,
                                    keyboard, &unbind);
-    input_focus_add_resource(&keyboard->focus, client_resource);
 
     /* Subtract one to remove terminating NULL character. */
     wl_keyboard_send_keymap(client_resource, WL_KEYBOARD_KEYMAP_FORMAT_XKB_V1,
                             keyboard->xkb.keymap.fd,
                             keyboard->xkb.keymap.size - 1);
+
+    input_focus_add_resource(&keyboard->focus, client_resource);
 
     if (version >= 4)
     {

--- a/libswc/seat.c
+++ b/libswc/seat.c
@@ -320,12 +320,20 @@ static int handle_libinput_data(int fd, uint32_t mask, void * data)
             {
                 struct libinput_event_pointer * event;
                 wl_fixed_t amount;
+                enum libinput_pointer_axis axis;
 
                 event = libinput_event_get_pointer_event(generic_event);
-                amount = wl_fixed_from_double
-                    (libinput_event_pointer_get_axis_value(event));
-                handle_axis(libinput_event_pointer_get_time(event),
-                            libinput_event_pointer_get_axis(event), amount);
+                for (axis = LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL;
+                     axis <= LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL;
+                     ++axis)
+                {
+                    if (libinput_event_pointer_has_axis(event, axis)) {
+                        amount = wl_fixed_from_double
+                            (libinput_event_pointer_get_axis_value(event, axis));
+                        handle_axis(libinput_event_pointer_get_time(event),
+                            axis, amount);
+                    }
+                }
                 break;
             }
             default:


### PR DESCRIPTION
I have encountered with following compile error
```
libswc/seat.c: In function 'handle_libinput_data':
libswc/seat.c:326:21: error: too few arguments to function 'libinput_event_pointer_get_axis_value'
                     (libinput_event_pointer_get_axis_value(event));
                     ^
In file included from libswc/seat.c:43:0:
/usr/include/libinput.h:693:1: note: declared here
 libinput_event_pointer_get_axis_value(struct libinput_event_pointer *event,
 ^
libswc/seat.c:328:29: error: implicit declaration of function 'libinput_event_pointer_get_axis' [-Werror=implicit-function-declaration]
                             libinput_event_pointer_get_axis(event), amount);
                             ^
```
I have libinput 0.9 installed.
So I write this patch to deal with it.
I didn’t tested it! I have no axis devices.