### PR TITLE
Add support for configuring libinput devices from window manager 

### DIFF
--- a/libswc/seat.c
+++ b/libswc/seat.c
@@ -255,6 +255,8 @@ handle_libinput_data(int fd, uint32_t mask, void *data)
 		case LIBINPUT_EVENT_DEVICE_ADDED:
 			device = libinput_event_get_device(generic_event);
 			update_capabilities(device_capabilities(device));
+			if (swc.manager->new_device)
+				swc.manager->new_device(device);
 			break;
 		case LIBINPUT_EVENT_KEYBOARD_KEY:
 			event.k = libinput_event_get_keyboard_event(generic_event);

--- a/libswc/swc.h
+++ b/libswc/swc.h
@@ -27,6 +27,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <wayland-server.h>
+#include <libinput.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -293,7 +294,7 @@ int swc_add_binding(enum swc_binding_type type, uint32_t modifiers, uint32_t val
 
 /**
  * This is a user-provided structure that swc will use to notify the display
- * server of new windows and screens.
+ * server of new windows, screens and input devices.
  */
 struct swc_manager {
 	/**
@@ -305,6 +306,11 @@ struct swc_manager {
 	 * Called when a new window is created.
 	 */
 	void (*new_window)(struct swc_window *window);
+
+	/**
+	 * Called when a new input device is detected.
+	 */
+	void (*new_device)(struct libinput_device *device);
 
 	/**
 	 * Called when the session gets activated (for example, startup or VT switch).

--- a/libswc/swc.h
+++ b/libswc/swc.h
@@ -27,7 +27,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <wayland-server.h>
-#include <libinput.h>
+
+struct libinput_device;
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Adds another optional callback to swc_manager, which is called when libinput detects new device. It's purpose is to be able to setup input devices from window manager.

Example: part of code from window manager which will set accel speed of touchpad
```c
#include <libinput.h>

...

static void
new_device(struct libinput_device *device)
{
    const char *dev_name = libinput_device_get_name(device);

    if (strcmp("AlpsPS/2 ALPS DualPoint TouchPad", dev_name) == 0) {
        libinput_device_config_accel_set_speed(device, 0.7);
    }
}

...

const struct swc_manager manager = {
    ...
    .new_device = &new_device
};
```