### PR TITLE
Add some stubs for newer protocol bits in the data manager, claiming support for protocol version 3.

### DIFF
--- a/libswc/data.c
+++ b/libswc/data.c
@@ -60,10 +60,25 @@ offer_receive(struct wl_client *client, struct wl_resource *offer, const char *m
 	close(fd);
 }
 
+static void
+offer_finish(struct wl_client *client, struct wl_resource *offer)
+{
+	/* XXX: Implement */
+}
+
+static void
+offer_set_actions(struct wl_client *client, struct wl_resource *offer,
+                  uint32_t dnd_actions, uint32_t preferred_action)
+{
+	/* XXX: Implement */
+}
+
 static const struct wl_data_offer_interface data_offer_impl = {
 	.accept = offer_accept,
 	.receive = offer_receive,
 	.destroy = destroy_resource,
+	.finish = offer_finish,
+	.set_actions = offer_set_actions,
 };
 
 static void

--- a/libswc/data_device.c
+++ b/libswc/data_device.c
@@ -27,6 +27,14 @@
 #include "util.h"
 
 static void
+release(struct wl_client *client, struct wl_resource *resource)
+{
+	struct data_device *data_device = wl_resource_get_user_data(resource);
+
+	data_device_destroy(data_device);
+}
+
+static void
 start_drag(struct wl_client *client, struct wl_resource *resource,
            struct wl_resource *source_resource, struct wl_resource *origin_resource,
            struct wl_resource *icon_resource, uint32_t serial)
@@ -59,6 +67,7 @@ set_selection(struct wl_client *client, struct wl_resource *resource, struct wl_
 static const struct wl_data_device_interface data_device_impl = {
 	.start_drag = start_drag,
 	.set_selection = set_selection,
+	.release = release
 };
 
 static void

--- a/libswc/data_device_manager.c
+++ b/libswc/data_device_manager.c
@@ -56,8 +56,8 @@ bind_data_device_manager(struct wl_client *client, void *data, uint32_t version,
 {
 	struct wl_resource *resource;
 
-	if (version > 1)
-		version = 1;
+	if (version > 3)
+		version = 3;
 
 	resource = wl_resource_create(client, &wl_data_device_manager_interface, version, id);
 	wl_resource_set_implementation(resource, &data_device_manager_impl, NULL, NULL);
@@ -66,5 +66,5 @@ bind_data_device_manager(struct wl_client *client, void *data, uint32_t version,
 struct wl_global *
 data_device_manager_create(struct wl_display *display)
 {
-	return wl_global_create(display, &wl_data_device_manager_interface, 1, NULL, &bind_data_device_manager);
+	return wl_global_create(display, &wl_data_device_manager_interface, 3, NULL, &bind_data_device_manager);
 }


### PR DESCRIPTION
This is enough to allow some SDL2 applications to work, e.g. [quakespasm](http://quakespasm.sourceforge.net/). It was done in my fork of swc that adds support for NetBSD and a new "seat" for the wscons input API, in case you're interested in that.