### PR TITLE
surface: Do not error if the transformation type is NORMAL.

### DIFF
--- a/libswc/surface.c
+++ b/libswc/surface.c
@@ -268,7 +268,10 @@ commit(struct wl_client *client, struct wl_resource *resource)
 static void
 set_buffer_transform(struct wl_client *client, struct wl_resource *surface, int32_t transform)
 {
-	wl_resource_post_error(surface, WL_SURFACE_ERROR_INVALID_TRANSFORM, "buffer transform not supported");
+	if (transform != WL_OUTPUT_TRANSFORM_NORMAL) {
+		wl_resource_post_error(surface, WL_SURFACE_ERROR_INVALID_TRANSFORM,
+					"buffer transform %" PRId32 " not supported", transform);
+	}
 }
 
 static void


### PR DESCRIPTION
Qt5 tries to set a surface's transformation type to `WL_OUTPUT_TRANSFORM_NORMAL` when an application is run, which currently causes the application to exit immediately with the message that the transformation is unsupported.

Match the behaviour of `set_buffer_scale` by not erroring if the requested transformation type is the default behaviour of swc. While here, make the error message a bit more useful.

This allows Qt5 applications to at least run again.