### PR TITLE
Bump data_device_manager_interface version to 3

### DIFF
--- a/libswc/data.c
+++ b/libswc/data.c
@@ -60,10 +60,30 @@ offer_receive(struct wl_client *client, struct wl_resource *offer, const char *m
 	close(fd);
 }
 
+static void
+offer_finish(struct wl_client *client, struct wl_resource *offer)
+{
+	(void)client;
+	(void)offer;
+	/* TODO: Implement */
+}
+
+static void
+offer_set_actions(struct wl_client *client, struct wl_resource *offer, uint32_t dnd_actions, uint32_t preferred_action)
+{
+	(void)client;
+	(void)offer;
+	(void)dnd_actions;
+	(void)preferred_action;
+	/* TODO: Implement */
+}
+
 static const struct wl_data_offer_interface data_offer_impl = {
 	.accept = offer_accept,
 	.receive = offer_receive,
 	.destroy = destroy_resource,
+	.finish = offer_finish,
+	.set_actions = offer_set_actions,
 };
 
 static void
@@ -87,9 +107,19 @@ error0:
 	wl_resource_post_no_memory(source);
 }
 
+static void
+source_set_actions(struct wl_client *client, struct wl_resource *resource, uint32_t dnd_actions)
+{
+	(void)client;
+	(void)resource;
+	(void)dnd_actions;
+	/* TODO: Implement */
+}
+
 static const struct wl_data_source_interface data_source_impl = {
 	.offer = source_offer,
 	.destroy = destroy_resource,
+	.set_actions = source_set_actions,
 };
 
 static void

--- a/libswc/data_device_manager.c
+++ b/libswc/data_device_manager.c
@@ -64,5 +64,5 @@ bind_data_device_manager(struct wl_client *client, void *data, uint32_t version,
 struct wl_global *
 data_device_manager_create(struct wl_display *display)
 {
-	return wl_global_create(display, &wl_data_device_manager_interface, 2, NULL, &bind_data_device_manager);
+	return wl_global_create(display, &wl_data_device_manager_interface, 3, NULL, &bind_data_device_manager);
 }


### PR DESCRIPTION
This is my second fix primarily for the foot terminal. Advertising data_device_manager version 3 allows it to launch properly.

I also added stubs for the new methods, and threw in todos as I saw for many of the other unimplemented methods.